### PR TITLE
Move Twist and Battery stuff into a Model-View system

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -155,7 +155,7 @@
 			</div>
 
 			<div id="joystick1" style="position: absolute; bottom: 0; width:18vw; height: 60vh;">
-				<input type="range" min="-1.0" max="1.0" value="0.0" step="0.01" class="linearjoy horizontal" id="joy_linear" oninput="Landscape.read_slider(this);" onchange="Landscape.reset_slider(this);">
+				<input type="range" min="-1.0" max="1.0" value="0.0" step="0.01" class="linearjoy horizontal" id="joy_linear" />
 			</div>
 
 		</div>
@@ -172,7 +172,7 @@
 			</div> 
 
 			<div id="joystick2" style="position: absolute; bottom: 0; right: 0; width:18vw;  height: 60vh;">
-				<input type="range" min="-1.0" max="1.0" value="0.0" step="0.01" class="linearjoy" id="joy_angular" oninput="Landscape.read_slider(this);" onchange="Landscape.reset_slider(this);">
+				<input type="range" min="-1.0" max="1.0" value="0.0" step="0.01" class="linearjoy" id="joy_angular" />
 			</div>
 
 		</div>

--- a/public/landscape_input.js
+++ b/public/landscape_input.js
@@ -1,36 +1,42 @@
-var inputmixer = {
-	linear: 0,
-	angular: 0
+class Landscape {
+
+	constructor() {
+		this.joy_linear = document.getElementById('joy_linear');
+		this.joy_angular = document.getElementById('joy_angular');
+
+		this.inputmixer = {
+			linear: 0,
+			angular: 0
+		}
+	}
+
+	bind_sliders(input_handler, reset_handler) {
+		var on_input = (event) => {
+			if(event.target === this.joy_linear)
+				this.inputmixer.linear = this.joy_linear.value
+			else if(event.target === this.joy_angular)
+				this.inputmixer.angular = this.joy_angular.value
+			input_handler(this.inputmixer.linear, this.inputmixer.angular);
+		}
+
+		var on_change = (event) => {
+			if(event.target === this.joy_linear)
+				this.inputmixer.linear = 0
+			else if(event.target === this.joy_angular)
+				this.inputmixer.angular = 0
+
+			event.target.value = 0
+			if(this.inputmixer.linear == 0 && this.inputmixer.angular == 0)
+				reset_handler();
+			else
+				input_handler(this.inputmixer.linear, this.inputmixer.angular);
+		}
+
+		this.joy_linear.addEventListener('input', on_input);
+		this.joy_angular.addEventListener('input', on_input);
+
+		this.joy_linear.addEventListener('change', on_change);
+		this.joy_angular.addEventListener('change', on_change);
+	}
 }
 
-class Landscape{
-
-	static get(id){
-		return document.getElementById(id);
-	}
-
-	static read_slider(element){
-
-		if(element.id == "joy_linear")
-			inputmixer.linear = element.value;
-		else if(element.id == "joy_angular")
-			inputmixer.angular = -element.value;
-		
-		Twist.set(inputmixer.linear, inputmixer.angular);
-	}
-
-	static reset_slider(element){
-
-		if(element.id == "joy_linear")
-			inputmixer.linear = 0;
-		else if(element.id == "joy_angular")
-			inputmixer.angular = 0;
-		
-		element.value = 0;
-		
-		if(inputmixer.linear == 0 && inputmixer.angular == 0)
-			Twist.clear();
-		else
-			Twist.set(inputmixer.linear, inputmixer.angular);
-	}
-}

--- a/public/portrait_input.js
+++ b/public/portrait_input.js
@@ -1,55 +1,99 @@
-var portrait_last_pressed;
+var scaleSize = "scale(1.5)";
+class Visuals{
 
-class Portrait{
-
-	static inputmux(target){
-
-		switch(target.id){
-			case "pforward_left": 	Twist.set(1,1);		break;
-			case "pforward":		Twist.set(1,0);		break;
-			case "pforward_right":	Twist.set(1,-1);	break;
-
-			case "pleft":			Twist.set(0,1);		break;
-			case "pstop":			Twist.set(0,0);		break;
-			case "pright":			Twist.set(0,-1);	break;
-
-			case "pbackward_left":	Twist.set(-1,-1);	break;
-			case "pbackward":		Twist.set(-1,0);	break;
-			case "pbackward_right":	Twist.set(-1,1);	break;
-			default: return;
-		}
-
-		Visuals.hover(target);
-		portrait_last_pressed = target;
+	static hover(el){
+		el.style.transform = scaleSize;
+		el.style.webkitTransform = scaleSize;
+		el.style.msTransform  = scaleSize;
 	}
+
+	static unhover(el){
+		el.style.transform = "scale(1.0)";
+		el.style.webkitTransform = "scale(1.0)";
+		el.style.msTransform  = "scale(1.0)";
+	}
+
 }
 
-document.documentElement.addEventListener('mousedown', function(e){
-	if(state.is_touchscreen)
-		return;
-	Portrait.inputmux(event.target);
-});
-
-document.documentElement.addEventListener('mouseup', function(e){
-	if(state.is_touchscreen)
-		return;
-	
-	if(portrait_last_pressed != undefined){
-		Visuals.unhover(portrait_last_pressed);
-		portrait_last_pressed = undefined;
-		Twist.clear();
-	}
-});
-
-document.documentElement.addEventListener('touchstart', function(e){
-	Portrait.inputmux(event.target);
-});
-
-document.documentElement.addEventListener('touchend', function(e){
-	if(portrait_last_pressed != undefined){
-		Visuals.unhover(portrait_last_pressed);
-		Twist.clear();
+// Joystick is still global state because settings interacts with it
+var joystick = undefined;
+class Portrait {
+	constructor() {
+		this.portrait_last_pressed = undefined;
 	}
 
-});
+	bind_buttons = (input_handler, reset_handler) => {
+		var on_press = (e) => {
+			var target = event.target
+			switch(target.id){
+				case "pforward_left": 	input_handler(1,1);	break;
+				case "pforward":	input_handler(1,0);	break;
+				case "pforward_right":	input_handler(1,-1);	break;
+
+				case "pleft":		input_handler(0,1);	break;
+				case "pstop":		input_handler(0,0);	break;
+				case "pright":		input_handler(0,-1);	break;
+
+				case "pbackward_left":	input_handler(-1,-1);	break;
+				case "pbackward":	input_handler(-1,0);	break;
+				case "pbackward_right":	input_handler(-1,1);	break;
+				default: return;
+			}
+
+			Visuals.hover(target);
+			this.portrait_last_pressed = target;
+		}
+		var on_unpress = (e) => {
+			if(this.portrait_last_pressed != undefined){
+				Visuals.unhover(this.portrait_last_pressed);
+				this.portrait_last_pressed = undefined;
+				reset_handler();
+			}
+		}
+		document.documentElement.addEventListener('mousedown', on_press);
+		document.documentElement.addEventListener('touchstart', on_press);
+
+		document.documentElement.addEventListener('mouseup', on_unpress);
+		document.documentElement.addEventListener('touchend', on_unpress);
+	}
+
+	bind_joystick = (input_handler, reset_handler) => {
+		var polling = () => {
+			let portraitmode = window.innerWidth < window.innerHeight;
+
+			if(settings.use_joystick)
+			{	
+				if(portraitmode){
+					if(joystick == undefined)
+						Settings.show_joystick();
+				}else if(joystick != undefined)
+					Settings.hide_joystick();
+			}
+			else if(joystick != undefined)
+				Settings.hide_joystick();
+
+			if(settings.use_joystick && portraitmode){
+				if(joystick._pressed) {
+					let ang = 0;
+					let lin = 0;
+
+					if(Math.sqrt(Math.pow(joystick.deltaX(),2) + Math.pow(joystick.deltaY(),2)) > joystick._stickRadius * 0.1)
+					{
+						ang = -joystick.deltaX()/joystick._stickRadius;
+						lin = -joystick.deltaY()/joystick._stickRadius;
+					}
+
+					if(lin < 0)
+						ang = -ang;
+
+					console.log("joy: lin="+lin.toFixed(2)+" ang="+ang.toFixed(2));
+					input_handler(lin,ang);
+				} else {
+					reset_handler();
+				}
+			} 
+		}
+		setInterval(polling, 100);
+	}
+}
 

--- a/public/roslink.js
+++ b/public/roslink.js
@@ -49,18 +49,6 @@ ros.on('close', function() {
 	document.getElementById("lconnstatus").style.color = "red";
 });
 
-var cmdVel = new ROSLIB.Topic({
-	ros : ros,
-	name : '/cmd_vel',
-	messageType : 'geometry_msgs/Twist'
-});
-
-var batterytopic = new ROSLIB.Topic({
-	ros : ros,
-	name : '/battery_state',
-	messageType : 'sensor_msgs/BatteryState'
-});
-
 var imageTopic = new ROSLIB.Topic({
 	ros : ros,
 	name : '/raspicam_node/image/compressed',
@@ -107,49 +95,7 @@ imageTopic.subscribe(function(msg) {
 		document.getElementById("lvideostream").src = "data:image/jpg;base64,"+msg.data
 });
 
-var battery_display_image = -1
-
-batterytopic.subscribe(function(msg) {
-	//console.log('Received message on ' + batterytopic.name + ': ' + JSON.stringify(msg));
-
-	battery.voltage = parseFloat(msg.voltage) * 0.2 + battery.voltage * 0.8;
-	battery.percentage = parseFloat(msg.percentage) * 0.2 + battery.percentage * 0.8;
-
-	let displayvolt = Math.round(battery.voltage*10)/10;
-	let imageperc = Math.ceil(battery.percentage*4)*25;
-	let displayperc = Math.round(battery.percentage*100);
-
-	if(battery_display_image != imageperc)
-	{
-		battery_display_image = imageperc;
-		document.getElementById("pbatteryicon").src = "assets/img/"+imageperc+".svg";
-		document.getElementById("lbatteryicon").src = "assets/img/"+imageperc+".svg";
-	}
-
-	document.getElementById("batt_voltage").innerHTML = "Voltage: "+displayvolt.toFixed(1)+" V";
-	document.getElementById("batt_percentage").innerHTML = "Percentage: "+displayperc+" %";
-});
-
-class ROSLink{
-
-	static twist(forward, rotate){
-		if(!connected)
-			return;
-
-		let twist = new ROSLIB.Message({
-			linear : {
-				x : forward * settings.linear,
-				y : 0,
-				z : 0
-			},
-			angular : {
-				x : 0,
-				y : 0,
-				z : rotate * settings.angular
-			}
-		});
-		cmdVel.publish(twist);
-	}
+class ROSLink {
 
 	static update(){
 		Settings.fetch();


### PR DESCRIPTION
The basic idea is separate the data handling and the display/user
handling parts of the code. The data and ROS handling goes into Models
that encapsulate the data reading and writing. These can then be bound
to views that display the data and handle user interaction.

This effort started in the avalon_web repository, but we are moving it
here now. These are the relevant commit messages from that effort:

    Convert the driving inputs to Views that bind to Twist

    This converts all of the Twist handling stuff into a more modular
    MVC structure.

    The use of arrow function the "() => { }" syntax is because javascript
    is stupid about "this" and the arrow syntax fixes this. In an arrow
    function "this" is bound to the surrounding scope of the function, not
    the function's caller. This allows us to make these functions callbacks
    without having to do weird binding things.

    Apply MVC to the battery stuff.

    Shows application of the the MVC model for the data coming in from
    ROS and going to the UI.